### PR TITLE
fix: improve italic and strikethrough formatting

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "logseq-export-block",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Export Logseq blocks to different markdown formats (Slack, WhatsApp, Google Docs and Rich Text)",
   "main": "dist/index.html",
   "type": "module",

--- a/src/core/clipboard-utils.ts
+++ b/src/core/clipboard-utils.ts
@@ -24,11 +24,11 @@ export function markdownToHtml(markdown: string): string {
   // Convert bold
   html = html.replace(/\*([^*]+)\*/g, '<b>$1</b>');
 
-  // Convert italic
-  html = html.replace(/_([^_]+)_/g, '<i>$1</i>');
+  // Convert italic - use a more specific regex to handle various formats
+  html = html.replace(/_(.*?)_/g, '<i>$1</i>');
 
-  // Convert strikethrough
-  html = html.replace(/~([^~]+)~/g, '<s>$1</s>');
+  // Convert strikethrough - use a more specific regex
+  html = html.replace(/~(.*?)~/g, '<s>$1</s>');
 
   // Convert code
   html = html.replace(/`([^`]+)`/g, '<code>$1</code>');

--- a/src/exports/slack/formatter.ts
+++ b/src/exports/slack/formatter.ts
@@ -39,10 +39,12 @@ export class SlackFormatter implements BlockFormatter {
     // Bold: Convert **text** to *text* (Slack uses single asterisks)
     formattedContent = formattedContent.replace(/\*\*(.*?)\*\*/g, '*$1*');
 
-    // Italic: Convert __text__ or _text_ to _text_
+    // Italic: Convert __text__ to _text_ (Slack italic)
     formattedContent = formattedContent.replace(/__(.*?)__/g, '_$1_');
+    // Make sure single underscore italic is preserved
+    formattedContent = formattedContent.replace(/(?<!\w)_([^_]+)_(?!\w)/g, '_$1_');
 
-    // Strikethrough: Convert ~~text~~ to ~text~ (Slack uses single tildes)
+    // Strikethrough: Convert ~~text~~ to ~text~ (Slack strikethrough)
     formattedContent = formattedContent.replace(/\~\~(.*?)\~\~/g, '~$1~');
 
     // Fix links for Slack format


### PR DESCRIPTION
- Update regex patterns in clipboard-utils.ts to better handle nested formatting
- Add specific regex in Slack formatter to preserve single underscore italic
- Fix strikethrough formatting to handle edge cases

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of italic and strikethrough markdown formatting for more accurate conversion to HTML and Slack markdown, ensuring multiple or nested formats are processed correctly.

- **Chores**
  - Updated the application version number.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->